### PR TITLE
Fix br tag conversion to newlines in goodreads book descriptions

### DIFF
--- a/goodreads/book.go
+++ b/goodreads/book.go
@@ -142,7 +142,7 @@ func (e *Edition) Sanitise() {
 	// not convert them to new lines properly
 	e.Description = descriptionAlternativeCoverRegex.ReplaceAllString(e.Description, "")
 	// HACK: html2text only handles <br> and <br/>, goodreads uses <br />
-	// replace unsupported br tag is a supported one
+	// replace unsupported br tag with a supported one
 	e.Description = breakTagRegex.ReplaceAllString(e.Description, "<br>")
 	e.Description = html2text.HTML2TextWithOptions(e.Description, html2text.WithUnixLineBreaks())
 	e.Description = strings.TrimSpace(e.Description)

--- a/goodreads/book.go
+++ b/goodreads/book.go
@@ -141,7 +141,9 @@ func (e *Edition) Sanitise() {
 	// Break tags need to be specially handled to add new lines as html2text does
 	// not convert them to new lines properly
 	e.Description = descriptionAlternativeCoverRegex.ReplaceAllString(e.Description, "")
-	e.Description = breakTagRegex.ReplaceAllString(e.Description, "\n")
+	// HACK: html2text only handles <br> and <br/>, goodreads uses <br />
+	// replace unsupported br tag is a supported one
+	e.Description = breakTagRegex.ReplaceAllString(e.Description, "<br>")
 	e.Description = html2text.HTML2TextWithOptions(e.Description, html2text.WithUnixLineBreaks())
 	e.Description = strings.TrimSpace(e.Description)
 

--- a/goodreads/book_test.go
+++ b/goodreads/book_test.go
@@ -37,3 +37,40 @@ func TestUnmarshalGenres(t *testing.T) {
 	expectedGenres := goodreads.Genres{"Fantasy", "Classic", "Fiction"}
 	require.Equal(t, expectedGenres, genres)
 }
+
+func TestBookUnmarshalBrTagReplacement(t *testing.T) {
+	testXML := `
+	<GoodreadsResponse>
+		<book>
+			<id>123</id>
+			<title>Test Book</title>
+			<description><![CDATA[This is a test description.<br />This should be on a new line.<br/>Another line.<br>Final line.]]></description>
+			<work>
+				<original_title>Test Book</original_title>
+				<ratings_sum>100</ratings_sum>
+				<ratings_count>10</ratings_count>
+			</work>
+			<popular_shelves>
+				<shelf name="fiction" count="100"/>
+			</popular_shelves>
+		</book>
+	</GoodreadsResponse>
+	`
+
+	var response struct {
+		Book goodreads.Book `xml:"book"`
+	}
+
+	err := xml.Unmarshal([]byte(testXML), &response)
+	require.NoError(t, err)
+
+	description := response.Book.BestEdition.Description
+	t.Logf("Description after processing: %q", description)
+
+	// Verify that <br> tags have been correctly converted to newlines
+	require.Contains(t, description, "test description.\nThis should be on a new line.\nAnother line.\nFinal line.")
+
+	// Verify that no HTML br tags remain
+	require.NotContains(t, description, "<br")
+	require.NotContains(t, description, "br>")
+}

--- a/goodreads/book_test.go
+++ b/goodreads/book_test.go
@@ -44,7 +44,7 @@ func TestBookUnmarshalBrTagReplacement(t *testing.T) {
 		<book>
 			<id>123</id>
 			<title>Test Book</title>
-			<description><![CDATA[This is a test description.<br />This should be on a new line.<br/>Another line.<br>Final line.]]></description>
+			<description><![CDATA[Test description<br />2. line<br/>3. line<br>4. line]]></description>
 			<work>
 				<original_title>Test Book</original_title>
 				<ratings_sum>100</ratings_sum>
@@ -68,7 +68,7 @@ func TestBookUnmarshalBrTagReplacement(t *testing.T) {
 	t.Logf("Description after processing: %q", description)
 
 	// Verify that <br> tags have been correctly converted to newlines
-	require.Contains(t, description, "test description.\nThis should be on a new line.\nAnother line.\nFinal line.")
+	require.Contains(t, description, "Test description\n2. line\n3. line\n4. line")
 
 	// Verify that no HTML br tags remain
 	require.NotContains(t, description, "<br")


### PR DESCRIPTION
- Replace <br /> tags with <br> before html2text processing
- html2text library doesn't handle <br /> (with space) format
- Add test to verify br tag replacement works correctly

Fixes #16